### PR TITLE
fixed verification error: imported jwt

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const jwt = require("jsonwebtoken");
 require("dotenv").config();
 
 const { generateToken, getMailOptions, getTransport } = require("./service.js");


### PR DESCRIPTION
The verification error was because i did not do this: const jwt = require("jsonwebtoken") in the index.js file. After i did this the verification started working.